### PR TITLE
Remove dataSource.dbCreate param

### DIFF
--- a/server/config/rundeck-config.properties.template
+++ b/server/config/rundeck-config.properties.template
@@ -16,7 +16,6 @@ dataSource.password=${RUNDECK_DATABASE_PASSWORD}
 dataSource.dialect=org.rundeck.hibernate.RundeckOracleDialect
 dataSource.properties.validationQuery=SELECT 1 FROM DUAL
 
-dataSource.dbCreate=update
 grails.plugin.databasemigration.updateOnStart=true
 
 # Pre Auth mode settings


### PR DESCRIPTION
The setting `dataSource.dbCreate=update` should not be used as it is from an old version of RunDeck and now causes issues with initialisation of the RunDeck database, so have removed that parameter from the config.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1485