### PR TITLE
Add Slack notification plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,13 @@ COPY --chown=rundeck:rundeck etc ${RDECK_BASE}/etc/
 COPY --chown=rundeck:rundeck bin ${RDECK_BASE}/bin/
 COPY --chown=rundeck:rundeck server ${RDECK_BASE}/server/
 
-# Add ojdbc jar for Oracle DB
+# Add ojdbc jar for Oracle DB and any additional plugin jars
 RUN mkdir -p ${RDECK_BASE}/server/lib && \
     cd ${RDECK_BASE}/server/lib && \
-    curl ${ARTIFACTORY_BASE_URL}/virtual-release/com/oracle/database/jdbc/ojdbc8/21.3.0.0/ojdbc8-21.3.0.0.jar -o ojdbc8-21.3.0.0.jar
+    curl ${ARTIFACTORY_BASE_URL}/virtual-release/com/oracle/database/jdbc/ojdbc8/21.3.0.0/ojdbc8-21.3.0.0.jar -o ojdbc8-21.3.0.0.jar && \
+    mkdir -p ${RDECK_BASE}/libext && \
+    cd ${RDECK_BASE}/libext && \
+    curl ${ARTIFACTORY_BASE_URL}/virtual-release/com/bitplaces/rundeck/slack-notification/1.2.4/slack-notification-1.2.4.jar -o slack-notification-1.2.4.jar
 
 
 CMD ["/apps/rundeck/bin/start-rundeck.sh"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ In order to use the image, a number of environment properties need to be defined
 |RUNDECK_DATABASE_URL|The jdbc url to connect to the Oracle database with|``jdbc:oracle:thin:@my-db.staging.heritage.aws.internal:1529:MYDB``
 |RUNDECK_DATABASE_USERNAME|The database username|``myusername``
 |RUNDECK_DATABASE_PASSWORD|The database user password|``mypassword``
+|SLACK_WEBHOOK_TOKEN|An environment specific token for using the Slack notification plugin.  This allows a different webhook to be used in Staging and Live so that the notifications go to different Slack channels, such as ``#rundeck_test`` and ``#rundeck_prod``|``T0ABCDEFG/blahblah/blahblahblahblahblah``
 
 
 ### Building the image

--- a/etc/framework.properties.template
+++ b/etc/framework.properties.template
@@ -34,3 +34,5 @@ framework.ssh.user = rundeck
 # "0" value means wait forever.
 framework.ssh.timeout = 0
 
+framework.plugin.Notification.SlackNotification.webhook_token=${SLACK_WEBHOOK_TOKEN}
+framework.plugin.Notification.SlackNotification.webhook_base_url=https://hooks.slack.com/services


### PR DESCRIPTION
Adds a slack notification plugin and some properties that set a default for the webhook destination and a new environment variable, `SLACK_WEBHOOK_TOKEN`, that allows a different token to be used per environment without having to set it as part of the job configuration.  

Resolves:
https://companieshouse.atlassian.net/browse/CM-1496