### PR TITLE
Install AWS CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,16 @@ RUN mkdir -p /apps && \
     yum clean all && \
     rm -rf /var/cache/yum
 
+# Install AWS CLI
+COPY awscli-exe-linux-x86_64-*.zip ${RDECK_BASE}/awscliv2.zip
+RUN cd ${RDECK_BASE} && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -r awscliv2.zip
+
+# Install RunDeck war
 USER rundeck
-
 COPY rundeck-*.war ${RDECK_BASE}
-
 RUN cd ${RDECK_BASE} && \
     /usr/java/jdk-8/bin/java -Xmx4g -jar rundeck-*.war --installonly
 

--- a/README.md
+++ b/README.md
@@ -29,4 +29,8 @@ To build the image, from the root of this repo, run:
 
     docker build -t chips-rundeck .
 
-The build expects there to be a rundeck war installer package in the root of the repo - e.g.  rundeck-#.#.#-########.war.
+The build expects the following in the root of the checked out repo:
+- A rundeck war install package - e.g. rundeck-#.#.#-########.war.
+- The AWS CLI install package - e.g. awscli-exe-linux-x86_64-#.#.#.zip
+
+Those packages are put into place by a Concourse pipeline in CH, but can be manually placed if building locally.  


### PR DESCRIPTION
Add AWS CLI so that RunDeck can operate with AWS APIs.  

This depends on the AWS CLI installation package being placed in the root of the checked out repo prior to running docker build, which requires an update to the Concourse pipeline.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1495