### PR TITLE
Add email server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ In order to use the image, a number of environment properties need to be defined
 |RUNDECK_DATABASE_USERNAME|The database username|``myusername``
 |RUNDECK_DATABASE_PASSWORD|The database user password|``mypassword``
 |SLACK_WEBHOOK_TOKEN|An environment specific token for using the Slack notification plugin.  This allows a different webhook to be used in Staging and Live so that the notifications go to different Slack channels, such as ``#rundeck_test`` and ``#rundeck_prod``|``T0ABCDEFG/blahblah/blahblahblahblahblah``
+|EMAIL_SERVER_HOST|The email (SMTP) server to use for email notifications|``my-smtp-server.blah.aws``
+|EMAIL_SERVER_FROM_ADDRESS|The email adress to use in the FROM field when sending email notifications|``rundeck@myemailaddress.com``
 
 
 ### Building the image

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ In order to use the image, a number of environment properties need to be defined
 |RUNDECK_DATABASE_PASSWORD|The database user password|``mypassword``
 |SLACK_WEBHOOK_TOKEN|An environment specific token for using the Slack notification plugin.  This allows a different webhook to be used in Staging and Live so that the notifications go to different Slack channels, such as ``#rundeck_test`` and ``#rundeck_prod``|``T0ABCDEFG/blahblah/blahblahblahblahblah``
 |EMAIL_SERVER_HOST|The email (SMTP) server to use for email notifications|``my-smtp-server.blah.aws``
-|EMAIL_SERVER_FROM_ADDRESS|The email adress to use in the FROM field when sending email notifications|``rundeck@myemailaddress.com``
+|EMAIL_SERVER_FROM_ADDRESS|The email address to use in the FROM field when sending email notifications|``rundeck@myemailaddress.com``
+|CSI_EMAIL_ADDRESSES|The email address(es) for notifications to the CSI team in Companies House.  This can be a comma separated list of email addresses or a single email address.  This can be referenced in Rundeck with ``${globals.csi-email-addresses}``|``csi@myemailaddress.com``
+|FESS_EMAIL_ADDRESSES|The email address(es) for notifications to the FESS team in Companies House. This can be a comma separated list of email addresses or a single email address.  This can be referenced in Rundeck with ``${globals.fess-email-addresses}``|``fess@myemailaddress.com``
 
 
 ### Building the image

--- a/etc/framework.properties.template
+++ b/etc/framework.properties.template
@@ -36,3 +36,10 @@ framework.ssh.timeout = 0
 
 framework.plugin.Notification.SlackNotification.webhook_token=${SLACK_WEBHOOK_TOKEN}
 framework.plugin.Notification.SlackNotification.webhook_base_url=https://hooks.slack.com/services
+
+# ---------------------------------------------------------------
+# Custom vars
+# ---------------------------------------------------------------
+
+framework.globals.csi-email-addresses=${CSI_EMAIL_ADDRESSES}
+framework.globals.fess-email-addresses=${FESS_EMAIL_ADDRESSES}

--- a/server/config/rundeck-config.properties.template
+++ b/server/config/rundeck-config.properties.template
@@ -29,3 +29,7 @@ rundeck.config.storage.provider.1.type=db
 rundeck.config.storage.provider.1.path=/
 
 rundeck.security.syncLdapUser=true
+
+# Email
+grails.mail.host=${EMAIL_SERVER_HOST}
+grails.mail.default.from=${EMAIL_SERVER_FROM_ADDRESS}


### PR DESCRIPTION
Some Rundeck jobs require email notifications to be sent, so I've added config to allow the SMTP server to be set and the FROM email address to be set from the environment.

Also added custom vars so that we can have per environment TO email addresses for CSI & FESS.

Partially resolves:
https://companieshouse.atlassian.net/browse/CM-1497