### PR TITLE
Customise GUI of Rundeck

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ In order to use the image, a number of environment properties need to be defined
 |EMAIL_SERVER_FROM_ADDRESS|The email address to use in the FROM field when sending email notifications|``rundeck@myemailaddress.com``
 |CSI_EMAIL_ADDRESSES|The email address(es) for notifications to the CSI team in Companies House.  This can be a comma separated list of email addresses or a single email address.  This can be referenced in Rundeck with ``${globals.csi-email-addresses}``|``csi@myemailaddress.com``
 |FESS_EMAIL_ADDRESSES|The email address(es) for notifications to the FESS team in Companies House. This can be a comma separated list of email addresses or a single email address.  This can be referenced in Rundeck with ``${globals.fess-email-addresses}``|``fess@myemailaddress.com``
+|INSTANCE_NAME|A string that is displayed on the login page and in the top menu bar|``Live Environment``
+|INSTANCE_NAME_BACKGROUND_COLOUR|The colour of the background for the INSTANCE_NAME string|``#123456``
+|INSTANCE_NAME_TEXT_COLOUR|The colour of the text for the INSTANCE_NAME string|``#000000``
 
 
 ### Building the image

--- a/i18n/messages.properties
+++ b/i18n/messages.properties
@@ -1,0 +1,3 @@
+# Override the date format for the activity list view
+jobslist.date.format=dd/MM/yyyy h:mm a
+jobslist.date.format.ko=DD/MM/YYYY h:mm a

--- a/server/config/rundeck-config.properties.template
+++ b/server/config/rundeck-config.properties.template
@@ -30,6 +30,11 @@ rundeck.config.storage.provider.1.path=/
 
 rundeck.security.syncLdapUser=true
 
+# GUI customisations
+rundeck.gui.instanceName=${INSTANCE_NAME}
+rundeck.gui.instanceNameLabelColor=${INSTANCE_NAME_BACKGROUND_COLOUR}
+rundeck.gui.instanceNameLabelTextColor=${INSTANCE_NAME_TEXT_COLOUR}
+
 # Email
 grails.mail.host=${EMAIL_SERVER_HOST}
 grails.mail.default.from=${EMAIL_SERVER_FROM_ADDRESS}


### PR DESCRIPTION
Adds an environment instance name that is displayed on the login page and at the top of the menu bar.  The background colour and text colour can be set so that it can be bright red on Live etc

Overrides the date format displayed on the job/command activity list view so that it is DD/MM/YYYY instead of MM/DD/YYYY.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1502