### PR TITLE
Tidy up of sanity and login check scripts

### DIFF
--- a/scripts/service-checks/CICSLoginCheck.jmx
+++ b/scripts/service-checks/CICSLoginCheck.jmx
@@ -173,7 +173,7 @@
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
         </HTTPSamplerProxy>
         <hashTree/>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/CICWEB/examiner/logout.do" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/CICWEB/JSP/close.jsp" enabled="true">
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
@@ -181,7 +181,7 @@
           <stringProp name="HTTPSampler.port"></stringProp>
           <stringProp name="HTTPSampler.protocol"></stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/CICWEB/examiner/logout.do</stringProp>
+          <stringProp name="HTTPSampler.path">/CICWEB/JSP/close.jsp</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/scripts/service-checks/chips-login-check.sh
+++ b/scripts/service-checks/chips-login-check.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
+echo "Starting CHIPSLoginCheck"
 
-outfile=$1_$2_CHIPSLoginCheck.jtl
+logfile=/tmp/$1_$2_CHIPSLoginCheck.log
+outfile=/tmp/$1_$2_CHIPSLoginCheck.jtl
 
 rm -f ${outfile}
 
-~/bin/apache-jmeter-?.?/bin/jmeter.sh -n -t /apps/rundeck/scripts/service-checks/CHIPSLoginCheck.jmx -Jchips_host=$1 -Jchips_port=443 -Jchips_protocol=https -Jchips_username="$2" -Jchips_password="$3" -l ${outfile} > /dev/null
+~/bin/apache-jmeter-?.?/bin/jmeter.sh -n -t /apps/rundeck/scripts/service-checks/CHIPSLoginCheck.jmx -Jchips_host=$1 -Jchips_port=443 -Jchips_protocol=https -Jchips_username="$2" -Jchips_password="$3" -j ${logfile} -l ${outfile} > /dev/null
 
 cat ${outfile}
 
 # Check for any failed responses
-awk -F, '{print $8}' ${outfile} | grep false
+grep ",false," ${outfile}
 false_check_result_code=$?
 
 if [ ${false_check_result_code} -eq 1 ]

--- a/scripts/service-checks/chips-sanity-check.sh
+++ b/scripts/service-checks/chips-sanity-check.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
+echo "Starting CHIPSSanityCheck"
 
-outfile=$1_$2_CHIPSSanityCheck.jtl
+logfile=/tmp/$1_$2_CHIPSSanityCheck.log
+outfile=/tmp/$1_$2_CHIPSSanityCheck.jtl
 
 rm -f ${outfile}
 
-~/bin/apache-jmeter-?.?/bin/jmeter.sh -n -t /apps/rundeck/scripts/service-checks/CHIPSSanityCheck.jmx -Jchips_host=$1.${RD_JOB_PROJECT,,}.heritage.aws.internal -Jchips_port=$2 -Jchips_protocol=http -Jchips_username="$3" -Jchips_password="$4" -l ${outfile} > /dev/null
+~/bin/apache-jmeter-?.?/bin/jmeter.sh -n -t /apps/rundeck/scripts/service-checks/CHIPSSanityCheck.jmx -Djava.util.prefs.userRoot=/tmp/$1_$2_CHIPSSanityCheck -Jchips_host=$1.${RD_JOB_PROJECT,,}.heritage.aws.internal -Jchips_port=$2 -Jchips_protocol=http -Jchips_username="$3" -Jchips_password="$4" -j ${logfile} -l ${outfile} > /dev/null
 
 cat ${outfile}
 
 # Check for any failed responses
-awk -F, '{print $8}' ${outfile} | grep false
+grep ",false," ${outfile}
 false_check_result_code=$?
 
 if [ ${false_check_result_code} -eq 1 ]

--- a/scripts/service-checks/cics-login-check.sh
+++ b/scripts/service-checks/cics-login-check.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
+echo "Starting CICSLoginCheck"
 
-outfile=$1_$2_CICSLoginCheck.jtl
+logfile=/tmp/$1_$2_CICSLoginCheck.log
+outfile=/tmp/$1_$2_CICSLoginCheck.jtl
 
 rm -f ${outfile}
 
-~/bin/apache-jmeter-?.?/bin/jmeter.sh -n -t /apps/rundeck/scripts/service-checks/CICSLoginCheck.jmx -Jcics_host=$1 -Jcics_username="$2" -Jcics_password="$3" -l ${outfile} > /dev/null
+~/bin/apache-jmeter-?.?/bin/jmeter.sh -n -t /apps/rundeck/scripts/service-checks/CICSLoginCheck.jmx -Jcics_host=$1 -Jcics_username="$2" -Jcics_password="$3" -j ${logfile} -l ${outfile} > /dev/null
 
 cat ${outfile}
 
 # Check for any failed responses
-awk -F, '{print $8}' ${outfile} | grep false
+grep ",false," ${outfile}
 false_check_result_code=$?
 
 if [ ${false_check_result_code} -eq 1 ]


### PR DESCRIPTION
Moves output and logs files to the /tmp folder and improves the detection of errors.

Also changes CICS logout request to reference JSP directly to avoid port 80 --> 443 redirect.

Additionally, sets the `java.util.prefs.userRoot` property for the CHIPS Sanity check as there are multiple 
JVM instances running for that check and there were locking errors being logged (although it still worked fine).

Resolves:
https://companieshouse.atlassian.net/browse/CM-1499