### PR TITLE
Reference new SNS notification plugin version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p ${RDECK_BASE}/server/lib && \
     mkdir -p ${RDECK_BASE}/libext && \
     cd ${RDECK_BASE}/libext && \
     curl ${ARTIFACTORY_BASE_URL}/virtual-release/com/bitplaces/rundeck/slack-notification/1.2.4/slack-notification-1.2.4.jar -o slack-notification-1.2.4.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/virtual-release/com/inokara/rundeck/aws-sns-notification-plugin/0.0.1/aws-sns-notification-plugin-0.0.1.jar -o aws-sns-notification-plugin-0.0.1.jar 
+    curl ${ARTIFACTORY_BASE_URL}/virtual-release/uk/gov/companieshouse/rundeck-sns-notification-plugin/1.0.1/rundeck-sns-notification-plugin-1.0.1.jar -o rundeck-sns-notification-plugin-1.0.1.jar 
 
 
 CMD ["/apps/rundeck/bin/start-rundeck.sh"]


### PR DESCRIPTION
Use a new SNS notification plugin that allows the message contents to be fully configured.  This is required in order for XMatters to process messages received on a topic as it expects the format to match the messages generated by CloudWatch.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1527