### PR TITLE
Add TZ var to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ In order to use the image, a number of environment properties need to be defined
 |RUNDECK_DATABASE_USERNAME|The database username|``myusername``
 |RUNDECK_DATABASE_PASSWORD|The database user password|``mypassword``
 |RUNDECK_SERVER_UUID|A unique identifier for the Rundeck server.  Used by Rundeck when storing and then retrieving the SCM configuration from the DB.|``db20fdb5-b506-479a-baf2-68ea6fbf04c2``
+|TZ|The timezone that Rundeck uses. This is important for having consistent run times throughout the year when scheduling jobs.|``Europe/London``
 |SLACK_WEBHOOK_TOKEN|An environment specific token for using the Slack notification plugin.  This allows a different webhook to be used in Staging and Live so that the notifications go to different Slack channels, such as ``#rundeck_test`` and ``#rundeck_prod``|``T0ABCDEFG/blahblah/blahblahblahblahblah``
 |EMAIL_SERVER_HOST|The email (SMTP) server to use for email notifications|``my-smtp-server.blah.aws``
 |EMAIL_SERVER_FROM_ADDRESS|The email address to use in the FROM field when sending email notifications|``rundeck@myemailaddress.com``


### PR DESCRIPTION
Document the TZ environment variable, that is used to set the timezone of Rundeck.   This should be `TZ="Europe/London"` in the rundeck.properties file for CH use.