### PR TITLE
Add support for API tokens and initial Concourse token

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ In order to use the image, a number of environment properties need to be defined
 |RUNDECK_SERVER_UUID|A unique identifier for the Rundeck server.  Used by Rundeck when storing and then retrieving the SCM configuration from the DB.|``db20fdb5-b506-479a-baf2-68ea6fbf04c2``
 |TZ|The timezone that Rundeck uses. This is important for having consistent run times throughout the year when scheduling jobs.|``Europe/London``
 |SLACK_WEBHOOK_TOKEN|An environment specific token for using the Slack notification plugin.  This allows a different webhook to be used in Staging and Live so that the notifications go to different Slack channels, such as ``#rundeck_test`` and ``#rundeck_prod``|``T0ABCDEFG/blahblah/blahblahblahblahblah``
+|CONCOURSE_TOKEN|A definition of the user, token and role for a static token that can be used to invoke the Rundeck API.  Referenced in ``/apps/rundeck/etc/tokens.properties.template``|``someuser: XXXxxxBlahSecretTokenBlahxxxXXX, somerole``
 |EMAIL_SERVER_HOST|The email (SMTP) server to use for email notifications|``my-smtp-server.blah.aws``
 |EMAIL_SERVER_FROM_ADDRESS|The email address to use in the FROM field when sending email notifications|``rundeck@myemailaddress.com``
 |CSI_EMAIL_ADDRESSES|The email address(es) for notifications to the CSI team in Companies House.  This can be a comma separated list of email addresses or a single email address.  This can be referenced in Rundeck with ``${globals.csi-email-addresses}``|``csi@myemailaddress.com``

--- a/bin/start-rundeck.sh
+++ b/bin/start-rundeck.sh
@@ -6,5 +6,6 @@ cd ${RDECK_BASE}
 envsubst < server/config/rundeck-config.properties.template > server/config/rundeck-config.properties
 envsubst < server/config/jaas-ldap.conf.template > server/config/jaas-ldap.conf
 envsubst < etc/framework.properties.template > etc/framework.properties
+envsubst < etc/tokens.properties.template > etc/tokens.properties
 
 /usr/java/jdk-8/jre/bin/java ${RUNDECK_JVM_OPTIONS} -jar /apps/rundeck/rundeck-*.war

--- a/etc/framework.properties.template
+++ b/etc/framework.properties.template
@@ -40,6 +40,9 @@ framework.plugin.Notification.SlackNotification.webhook_base_url=https://hooks.s
 # Server UUID - value doesn't matter but it needs to be set to allow Rundeck to find SCM config in DB
 rundeck.server.uuid=${RUNDECK_SERVER_UUID}
 
+# Static API tokens
+rundeck.tokens.file=/apps/rundeck/etc/tokens.properties
+
 # ---------------------------------------------------------------
 # Custom vars
 # ---------------------------------------------------------------

--- a/etc/tokens.properties.template
+++ b/etc/tokens.properties.template
@@ -1,0 +1,1 @@
+${CONCOURSE_TOKEN}


### PR DESCRIPTION
Allow API tokens to be configured using environment variables.
  
One initial variable has been added for Concourse using the env var `CONCOURSE_TOKEN`. 

Resolves:
https://companieshouse.atlassian.net/browse/CM-1549