### PR TITLE
Reference version 1.2.2 of ch-serverjre to pull in new chca cert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.2.1
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.2.2
 
 
 ENV RDECK_BASE=/apps/rundeck \


### PR DESCRIPTION
The new cert is included in ch-serverjre-1.2.2 which is needed as the previous cert is due to expire on 6th Aug.

Resolves:
https://companieshouse.atlassian.net/browse/SUP-1124
