### PR TITLE
Remove temporary aws directory after installing aws-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN cd ${RDECK_BASE}/bin && \
     if compgen -G "awscli-exe-linux-x86_64-*.zip" > /dev/null; then \
       unzip awscli-exe-linux-x86_64-*.zip && \
       ./aws/install && \
-      rm -r awscli-exe-linux-x86_64-*.zip; \
+      rm -r aws awscli-exe-linux-x86_64-*.zip; \
     fi; \
     if compgen -G "apache-jmeter-*.zip" > /dev/null; then \
       unzip apache-jmeter-*.zip && \


### PR DESCRIPTION
A temporary "aws" directory is created during the aws-cli install, that should be removed afterwards to reduce image size.
