### PR TITLE
Update E2E deployment scripts to handle dedicated environments

### DIFF
--- a/scripts/development/await-chips-startup.sh
+++ b/scripts/development/await-chips-startup.sh
@@ -3,46 +3,36 @@
 ##############################################################################
 #
 # This script checks to see if chips is running and returning a 200 HTTP code 
-# in a specific dev environment.
+# in a specific E2E environment via the ALB.
 # If the status code is not 200 then the script will retry until the supplied timeout 
 # is exceeded or 200 is returned.
 #
-# The script expects two arguments:
+# The script expects three arguments:
 # - name of the environment (e.g. cidev)
 # - timeout in seconds - i.e. how long to keep trying before exiting with a failure code
+# - the fully qualified hostname of the node on which this script is running (e.g.  myenv.mydomain.com)
+#   (normally provided by Rundeck)
 #
-# The script also expects the DEV_CONFIG_BUCKET_AND_PATH and 
-# DEV_CHIPS_BASE_URL env vars to be set.
 #
 ###############################################################################
 
-if [ "$#" -ne 2 ]
+if [ "$#" -ne 3 ]
 then
-  echo "Invalid number of arguments - expected three arguments: <env name> <timeout>"
+  echo "Invalid number of arguments - expected three arguments: <env name> <timeout> <hostname>"
   exit 1
 fi
 
 ENV_NAME=$1
 TIMEOUT=$2
+HOSTNAME=$3
 
-# Set up TMP folder specific to this script and environment
-TMP=/var/tmp/await-chips-startup/${ENV_NAME}
-mkdir -p ${TMP} 
-
-S3_VERSION_FILE=s3://${DEV_CONFIG_BUCKET_AND_PATH}/${ENV_NAME}/app-image-versions
-LOCAL_VERSION_FILE=${TMP}/app-image-versions
-
-# Download the existing file from S3
-aws s3 cp ${S3_VERSION_FILE} ${TMP}
-
-# Source the file so we can work out which port to connect to
-. ${LOCAL_VERSION_FILE} 
-CHIPS_CHECK_URL="${DEV_CHIPS_BASE_URL}:2${APP_INSTANCE_NUMBER}00/chips/cff"
+CHIPS_CHECK_URL="https://chips-${HOSTNAME}/chips/cff"
+echo "Checking connection to ${ENV_NAME} using ${CHIPS_CHECK_URL}"
 
 HTTP_STATUS=""
 while [[ ${HTTP_STATUS} != "200" ]]
 do
-  CURL_OUTPUT=$(curl -m 10 -s -I -X GET "${CHIPS_CHECK_URL}")
+  CURL_OUTPUT=$(curl -k -m 10 -s -I -X GET "${CHIPS_CHECK_URL}")
   CURL_EXIT_CODE=$?
 
   if [[ ${CURL_EXIT_CODE} = "28" ]]
@@ -60,11 +50,7 @@ do
       sleep 10
     else
       echo "Timed out after ${TIMEOUT} seconds"
-      rm -f ${LOCAL_VERSION_FILE}
       exit 1
     fi
   fi
 done
-
-# Clean up
-rm -f ${LOCAL_VERSION_FILE}

--- a/scripts/development/ec2-nodes.sh
+++ b/scripts/development/ec2-nodes.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+##############################################################################
+#
+# This script is used to return a list of nodes in the resourcejson Rundeck 
+# format.
+# The list is obtained by querying AWS with the aws ec2 describe-instances command 
+# and relies on identifying the instances by filtering on tags.
+# 
+# It is intended to be used as part of a script "node source" within Rundeck and requires
+# 5 parameters, as described in the usage text below.
+###############################################################################
+
+if [ "$#" -ne 5 ]
+then
+    echo "Incorrect number of arguments supplied"
+    echo 
+    echo "Usage: ec2-nodes.sh <domain name suffix> <username> <path to key> <filter tags> <name tag>"
+    echo "<domain name suffix> is a domain that is added to the returned name so that it is resolvable on the network - e.g. .myawsnetwork.com"
+    echo "<username> the user that Rundeck will use when connecting to the node via SSH"
+    echo "<path to key> is the Rundeck key storage path for the key to use when connecting via SSH"
+    echo "<filter tags> is a list of tag/value pairs that should be used for filtering the results, pipe separated - e.g. Service=CHIPS|config-base-path=*chips-e2e-configs"
+    echo "<name tag> is the instance tag to use for the returned node name - e.g. Name"
+    exit 1
+fi
+
+DOMAIN_NAME_SUFFIX=$1
+USERNAME=$2
+KEY_PATH=$3
+FILTER_TAGS=$4
+NAME_TAG=$5
+
+# Split out tags param and generate a filter for use with the aws cli
+OLDIFS=${IFS}
+IFS=\|
+for TAG_VALUE_PAIR in ${FILTER_TAGS}
+do
+  TAG=${TAG_VALUE_PAIR%%=*}
+  VALUE=${TAG_VALUE_PAIR##*=}
+  AWS_CLI_FILTER="${AWS_CLI_FILTER} Name=tag:${TAG},Values=${VALUE}"
+done
+IFS=${OLDIFS}
+
+# Call the aws cli to get a list of nodes
+E2E_INSTANCES=$(aws ec2 describe-instances --region eu-west-2 --filters ${AWS_CLI_FILTER} | jq -r '.Reservations[].Instances[].Tags[] | select(.Key=="'${NAME_TAG}'").Value')
+
+# Populate json output containing each instance
+echo -n "["
+FIRST=1
+for INSTANCE in ${E2E_INSTANCES}
+do
+  if [[ FIRST -eq 0 ]]; then
+    echo ","
+  else
+    FIRST=0
+  fi
+
+  echo -n "{
+    \"nodename\":\"${INSTANCE}\",
+    \"hostname\":\"${INSTANCE}${DOMAIN_NAME_SUFFIX}\",
+    \"username\":\"${USERNAME}\",
+    \"tags\":\"${INSTANCE}\",
+    \"ssh-key-storage-path\":\"${KEY_PATH}\"
+  }"
+done
+echo "]"


### PR DESCRIPTION
Updates the Rundeck E2E deployment scripts to work with the new environments that are hosted on separate EC2 instances.
The list of environments is now exposed in Rundeck using a "node source" script (`ec2-nodes.sh`) that uses EC2 instance metadata (tags) to identify the available environments.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-64