### PR TITLE
Support multi-cluster environments

### DIFF
--- a/scripts/development/await-chips-startup.sh
+++ b/scripts/development/await-chips-startup.sh
@@ -3,30 +3,29 @@
 ##############################################################################
 #
 # This script checks to see if chips is running and returning a 200 HTTP code 
-# in a specific E2E environment via the ALB.
+# in a specific E2E environment via the local listen address.
 # If the status code is not 200 then the script will retry until the supplied timeout 
 # is exceeded or 200 is returned.
 #
 # The script expects three arguments:
 # - name of the environment (e.g. cidev)
 # - timeout in seconds - i.e. how long to keep trying before exiting with a failure code
-# - the fully qualified hostname of the node on which this script is running (e.g.  myenv.mydomain.com)
-#   (normally provided by Rundeck)
+# - the listen port
 #
 #
 ###############################################################################
 
 if [ "$#" -ne 3 ]
 then
-  echo "Invalid number of arguments - expected three arguments: <env name> <timeout> <hostname>"
+  echo "Invalid number of arguments - expected three arguments: <env name> <timeout> <port>"
   exit 1
 fi
 
 ENV_NAME=$1
 TIMEOUT=$2
-HOSTNAME=$3
+PORT=$3
 
-CHIPS_CHECK_URL="https://chips-${HOSTNAME}/chips/cff"
+CHIPS_CHECK_URL="http://127.0.0.1:${PORT}/chips/cff"
 echo "Checking connection to ${ENV_NAME} using ${CHIPS_CHECK_URL}"
 
 HTTP_STATUS=""

--- a/scripts/development/update-app-image-versions.sh
+++ b/scripts/development/update-app-image-versions.sh
@@ -13,6 +13,38 @@
 #
 ###############################################################################
 
+function updateVersionFile() {
+  ADJUSTED_ENV_NAME=${1:-${ENV_NAME}}
+  echo "Updating app-image-versions for environment: ${ADJUSTED_ENV_NAME}"
+
+  S3_VERSION_FILE=s3://${DEV_CONFIG_BUCKET}/${DEV_CONFIG_BUCKET_ENV_PATH}/${ADJUSTED_ENV_NAME}/app-image-versions
+  LOCAL_VERSION_FILE=${TMP}/app-image-versions
+
+  # Check if the environment specific app-image-versions file exists
+  aws s3api head-object --bucket ${DEV_CONFIG_BUCKET} --key ${DEV_CONFIG_BUCKET_ENV_PATH}/${ADJUSTED_ENV_NAME}/app-image-versions > /dev/null 2>&1 || NO_VERSION_FILE=true
+  if [ ${NO_VERSION_FILE} ]; then
+    echo "Environment specific file not found at ${S3_VERSION_FILE} - creating one from s3://${DEV_CONFIG_BUCKET}/${DEV_CONFIG_BUCKET_ENV_PATH}/app-image-versions"
+    # Download the template file from S3
+    aws s3 cp s3://${DEV_CONFIG_BUCKET}/${DEV_CONFIG_BUCKET_ENV_PATH}/app-image-versions ${TMP}
+  else
+    # Download the existing file from S3
+    aws s3 cp ${S3_VERSION_FILE} ${TMP}
+  fi
+
+  # Modify the downloaded file to update the chips-app and chips-apache versions
+  sed -i "s/chips-app:.*/chips-app:${CHIPS_APP_VERSION}/" ${LOCAL_VERSION_FILE}
+  sed -i 's/chips-apache:.*/chips-apache:'${CHIPS_APACHE_VERSION}'/' ${LOCAL_VERSION_FILE}
+
+  echo "New ${LOCAL_VERSION_FILE}:"
+  cat ${LOCAL_VERSION_FILE}
+
+  # Upload the modified file back to S3
+  aws s3 cp ${LOCAL_VERSION_FILE} ${S3_VERSION_FILE}
+
+  # Clean up
+  rm -f ${LOCAL_VERSION_FILE}
+}
+
 if [ "$#" -ne 3 ]
 then
   echo "Invalid number of arguments - expected three arguments: <env name> <chips-app image version> <chips-apache image version>"
@@ -25,31 +57,23 @@ CHIPS_APACHE_VERSION=$3
 
 # Set up TMP folder specific to this script and environment
 TMP=/var/tmp/update-app-image-versions/${ENV_NAME}
-mkdir -p ${TMP} 
+mkdir -p ${TMP}
 
-S3_VERSION_FILE=s3://${DEV_CONFIG_BUCKET}/${DEV_CONFIG_BUCKET_ENV_PATH}/${ENV_NAME}/app-image-versions
-LOCAL_VERSION_FILE=${TMP}/app-image-versions
+# Identify if this is a multicluster environment, as there will be two 
+# app-image-versions files to update in that case
+# We check if it is multicluster by checking if there is a config folder chips-${ENV_NAME}0,
+MULTICLUSTER=false
+if [[ ${ENV_NAME} != chips-* ]]; then
+  aws s3api head-object --bucket ${DEV_CONFIG_BUCKET} --key ${DEV_CONFIG_BUCKET_ENV_PATH}/chips-${ENV_NAME}0/ > /dev/null 2>&1 && MULTICLUSTER=true
+fi
+echo "MULTICLUSTER=${MULTICLUSTER}"
 
-# Check if the environment specific app-image-versions file exists
-aws s3api head-object --bucket ${DEV_CONFIG_BUCKET} --key ${DEV_CONFIG_BUCKET_ENV_PATH}/${ENV_NAME}/app-image-versions > /dev/null 2>&1 || NO_VERSION_FILE=true
-if [ ${NO_VERSION_FILE} ]; then
-  echo "Environment specific file not found at ${S3_VERSION_FILE} - creating one from s3://${DEV_CONFIG_BUCKET}/${DEV_CONFIG_BUCKET_ENV_PATH}/app-image-versions"
-  # Download the template file from S3
-  aws s3 cp s3://${DEV_CONFIG_BUCKET}/${DEV_CONFIG_BUCKET_ENV_PATH}/app-image-versions ${TMP}
+if [ ${MULTICLUSTER} = true ]; then
+  # Update the app-image-versions for both chips-${ENV_NAME}0 and chips-${ENV_NAME}1
+  updateVersionFile chips-${ENV_NAME}0
+  updateVersionFile chips-${ENV_NAME}1
 else
-  # Download the existing file from S3
-  aws s3 cp ${S3_VERSION_FILE} ${TMP}
+  # Update the app-image-versions for the single environment
+  updateVersionFile
 fi
 
-# Modify the downloaded file to update the chips-app and chips-apache versions
-sed -i "s/chips-app:.*/chips-app:${CHIPS_APP_VERSION}/" ${LOCAL_VERSION_FILE}
-sed -i 's/chips-apache:.*/chips-apache:'${CHIPS_APACHE_VERSION}'/' ${LOCAL_VERSION_FILE}
-
-echo "New ${LOCAL_VERSION_FILE}:"
-cat ${LOCAL_VERSION_FILE}
-
-# Upload the modified file back to S3
-aws s3 cp ${LOCAL_VERSION_FILE} ${S3_VERSION_FILE}
-
-# Clean up
-rm -f ${LOCAL_VERSION_FILE}


### PR DESCRIPTION
Updates the development scripts to support multi-cluster (multi-instance) environments, by:
1.  using the local listen address when awaiting CHIPS startup, instead of the ALB address.
2. detecting whether there is an environment path named chips-<env>0 on S3 and updating the app versions file there and in chips-<env>-1 too.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-708